### PR TITLE
Fix for plotting wrt new cohort paradigm in BQ

### DIFF
--- a/api/data_access.py
+++ b/api/data_access.py
@@ -35,6 +35,11 @@ from bq_data_access.data_access import FeatureIdQueryDescription
 
 from api.pairwise import PairwiseInputVector, Pairwise
 from api.pairwise_api import PairwiseResults, PairwiseResultVector, PairwiseFilterMessage
+from api.api_helpers import sql_connection
+
+from projects.models import Study
+from cohorts.views import fetch_tcga_study_set
+
 import sys
 
 logger = logging.getLogger(__name__)
@@ -246,7 +251,7 @@ class FeatureDataEndpoints(remote.Service):
 
     # TODO refactor missing value logic out of this module
     @DurationLogged('FEATURE', 'GET_VECTORS')
-    def get_merged_feature_vectors(self, x_id, y_id, c_id, cohort_id_array, logTransform):
+    def get_merged_feature_vectors(self, x_id, y_id, c_id, cohort_id_array, logTransform, study_id_array):
         """
         Fetches and merges data for two or three feature vectors (see parameter documentation below).
         The vectors have to be an array of dictionaries, with each dictionary containing a 'value' field
@@ -284,7 +289,7 @@ class FeatureDataEndpoints(remote.Service):
         :return: PlotDataResponse
         """
 
-        async_params = [FeatureIdQueryDescription(x_id, cohort_id_array)]
+        async_params = [FeatureIdQueryDescription(x_id, cohort_id_array, study_id_array)]
 
         c_type, c_vec = ValueType.STRING, []
         y_type, y_vec = ValueType.STRING, []
@@ -292,9 +297,9 @@ class FeatureDataEndpoints(remote.Service):
         units = get_axis_units(x_id, y_id)
 
         if c_id is not None:
-            async_params.append(FeatureIdQueryDescription(c_id, cohort_id_array))
+            async_params.append(FeatureIdQueryDescription(c_id, cohort_id_array, study_id_array))
         if y_id is not None:
-            async_params.append(FeatureIdQueryDescription(y_id, cohort_id_array))
+            async_params.append(FeatureIdQueryDescription(y_id, cohort_id_array, study_id_array))
 
         async_result = get_feature_vectors_tcga_only(async_params)
 
@@ -459,7 +464,42 @@ class FeatureDataEndpoints(remote.Service):
                     logging.error("Invalid internal feature ID '{}'".format(feature_id))
                     raise NotFoundException()
 
-            return self.get_merged_feature_vectors(x_id, y_id, c_id, cohort_id_array, logTransform)
+            # Get the study IDs these cohorts' samples come from
+            cohort_vals = ()
+            cohort_params = ""
+
+            for cohort in cohort_id_array:
+                cohort_params += "%s,"
+                cohort_vals += (cohort,)
+
+            cohort_params = cohort_params[:-1]
+
+            db = sql_connection()
+            cursor = db.cursor()
+
+            tcga_studies = fetch_tcga_study_set()
+
+            cursor.execute("SELECT DISTINCT study_id FROM cohorts_samples WHERE cohort_id IN ("+cohort_params+");",cohort_vals)
+
+            # Only samples whose source studies are TCGA studies, or extended from them, should be used
+            confirmed_study_ids = []
+            unconfirmed_study_ids = []
+
+            for row in cursor.fetchall():
+                if row[0] in tcga_studies:
+                    if row[0] not in confirmed_study_ids:
+                        confirmed_study_ids.append(row[0])
+                elif row[0] not in unconfirmed_study_ids:
+                    unconfirmed_study_ids.append(row[0])
+
+            if len(unconfirmed_study_ids) > 0:
+                studies = Study.objects.filter(id__in=unconfirmed_study_ids)
+
+                for study in studies:
+                    if study.get_my_root_and_depth()['root'] in tcga_studies:
+                        confirmed_study_ids.append(study.id)
+
+            return self.get_merged_feature_vectors(x_id, y_id, c_id, cohort_id_array, logTransform, confirmed_study_ids)
         except NotFoundException as nfe:
             # Pass through NotFoundException so that it is not handled as Exception below.
             raise nfe

--- a/api/data_access.py
+++ b/api/data_access.py
@@ -38,7 +38,7 @@ from api.pairwise_api import PairwiseResults, PairwiseResultVector, PairwiseFilt
 from api.api_helpers import sql_connection
 
 from projects.models import Study
-from cohorts.views import fetch_tcga_study_set
+from cohorts.views import fetch_isbcgc_study_set
 
 import sys
 
@@ -477,7 +477,7 @@ class FeatureDataEndpoints(remote.Service):
             db = sql_connection()
             cursor = db.cursor()
 
-            tcga_studies = fetch_tcga_study_set()
+            tcga_studies = fetch_isbcgc_study_set()
 
             cursor.execute("SELECT DISTINCT study_id FROM cohorts_samples WHERE cohort_id IN ("+cohort_params+");",cohort_vals)
 

--- a/bq_data_access/data_access.py
+++ b/bq_data_access/data_access.py
@@ -103,9 +103,10 @@ class FeatureProviderFactory(object):
 
 
 class FeatureIdQueryDescription(object):
-    def __init__(self, feature_id, cohort_id_array):
+    def __init__(self, feature_id, cohort_id_array, study_id_array):
         self.feature_id = feature_id
         self.cohort_id_array = cohort_id_array
+        self.study_id_array = study_id_array
 
 
 class ProviderClassQueryDescription(object):
@@ -176,7 +177,8 @@ def submit_tcga_job(param_obj, bigquery_service, cohort_settings):
     provider = FeatureProviderFactory.from_parameters(param_obj, bigquery_service=bigquery_service)
     feature_id = param_obj.feature_id
     cohort_id_array = param_obj.cohort_id_array
-    job_reference = provider.get_data_job_reference(cohort_id_array, cohort_settings.dataset_id, cohort_settings.table_id)
+    study_id_array = param_obj.study_id_array
+    job_reference = provider.get_data_job_reference(cohort_id_array, cohort_settings.dataset_id, cohort_settings.table_id, study_id_array)
 
     logging.info("Submitted TCGA {job_id}: {fid} - {cohorts}".format(job_id=job_reference['jobId'], fid=feature_id,
                                                                              cohorts=str(cohort_id_array)))

--- a/bq_data_access/feature_data_provider.py
+++ b/bq_data_access/feature_data_provider.py
@@ -117,10 +117,10 @@ class FeatureDataProvider(object):
         result = self.unpack_query_response(query_result_array)
         return result
 
-    def submit_query_and_get_job_ref(self, project_id, project_name, dataset_name, table_name, feature_def, cohort_dataset, cohort_table, cohort_id_array):
+    def submit_query_and_get_job_ref(self, project_id, project_name, dataset_name, table_name, feature_def, cohort_dataset, cohort_table, cohort_id_array, study_id_array):
         bigquery_service = self.get_bq_service()
 
-        query_body = self.build_query(project_name, dataset_name, table_name, feature_def, cohort_dataset, cohort_table, cohort_id_array)
+        query_body = self.build_query(project_name, dataset_name, table_name, feature_def, cohort_dataset, cohort_table, cohort_id_array, study_id_array)
         query_job = self.submit_bigquery_job(bigquery_service, project_id, query_body)
 
         # Poll for completion of the query
@@ -130,12 +130,13 @@ class FeatureDataProvider(object):
 
         return self.job_reference
 
-    def get_data_job_reference(self, cohort_id_array, cohort_dataset, cohort_table):
+    def get_data_job_reference(self, cohort_id_array, cohort_dataset, cohort_table, study_id_array):
         project_id = settings.BQ_PROJECT_ID
         project_name = settings.BIGQUERY_PROJECT_NAME
         dataset_name = settings.BIGQUERY_DATASET
 
         result = self.submit_query_and_get_job_ref(project_id, project_name, dataset_name, self.table_name,
-                                                   self.feature_def, cohort_dataset, cohort_table, cohort_id_array)
+                                                   self.feature_def, cohort_dataset, cohort_table, cohort_id_array,
+                                                   study_id_array)
         return result
 

--- a/bq_data_access/gexp_data.py
+++ b/bq_data_access/gexp_data.py
@@ -24,6 +24,8 @@ from bq_data_access.errors import FeatureNotFoundException
 from bq_data_access.feature_value_types import ValueType, DataTypes
 from bq_data_access.utils import DurationLogged
 
+import sys
+
 TABLES = [
     {
         'table_id': 'mRNA_UNC_GA_RSEM',
@@ -106,25 +108,29 @@ class GEXPFeatureProvider(FeatureDataProvider):
     def process_data_point(self, data_point):
         return data_point['value']
 
-    def build_query(self, project_name, dataset_name, table_name, feature_def, cohort_dataset, cohort_table, cohort_id_array):
+    def build_query(self, project_name, dataset_name, table_name, feature_def, cohort_dataset, cohort_table, cohort_id_array, study_id_array):
         # Generate the 'IN' statement string: (%s, %s, ..., %s)
         cohort_id_stmt = ', '.join([str(cohort_id) for cohort_id in cohort_id_array])
+        study_id_stmt = ''
+        if study_id_array is not None:
+            study_id_stmt = ', '.join([str(study_id) for study_id in study_id_array])
 
-        query_template = \
-            ("SELECT ParticipantBarcode AS patient_id, SampleBarcode AS sample_id, AliquotBarcode AS aliquot_id, {value_field} AS value "
-             "FROM [{project_name}:{dataset_name}.{table_name}] AS gexp "
-             "WHERE {gene_label_field}='{gene_symbol}' "
-             "AND SampleBarcode IN ( "
-             "    SELECT sample_barcode "
-             "    FROM [{project_name}:{cohort_dataset}.{cohort_table}] "
-             "    WHERE cohort_id IN ({cohort_id_list})"
-             ") ")
+        query_template = "SELECT ParticipantBarcode AS patient_id, SampleBarcode AS sample_id, AliquotBarcode AS aliquot_id, {value_field} AS value " \
+             "FROM [{project_name}:{dataset_name}.{table_name}] AS gexp " \
+             "WHERE {gene_label_field}='{gene_symbol}' " \
+             "AND SampleBarcode IN ( " \
+             "     SELECT sample_barcode " \
+             "     FROM [{project_name}:{cohort_dataset}.{cohort_table}] " \
+             "     WHERE cohort_id IN ({cohort_id_list}) " \
+             "          AND (study_id IS NULL"
+
+        query_template += (" OR study_id IN ({study_id_list})))" if study_id_array is not None else "))")
 
         query = query_template.format(dataset_name=dataset_name, project_name=project_name, table_name=table_name,
                                       gene_label_field=GENE_LABEL_FIELD,
                                       gene_symbol=feature_def.gene, value_field=feature_def.value_field,
                                       cohort_dataset=cohort_dataset, cohort_table=cohort_table,
-                                      cohort_id_list=cohort_id_stmt)
+                                      cohort_id_list=cohort_id_stmt, study_id_list=study_id_stmt)
 
         logging.debug("BQ_QUERY_GEXP: " + query)
         return query

--- a/bq_data_access/maf_data.py
+++ b/bq_data_access/maf_data.py
@@ -71,9 +71,12 @@ def validate_input(query_table_id):
     if query_table_id not in valid_tables:
         raise Exception("Invalid table ID for maf")
 
-def build_query(project_name, dataset_name, table_name, gene, value_field, cohort_dataset, cohort_table, cohort_id_array):
+def build_query(project_name, dataset_name, table_name, gene, value_field, cohort_dataset, cohort_table, cohort_id_array, study_id_array):
     # Generate the 'IN' statement string: (%s, %s, ..., %s)
     cohort_id_stmt = ', '.join([str(cohort_id) for cohort_id in cohort_id_array])
+    study_id_stmt = ''
+    if study_id_array is not None:
+        study_id_stmt = ', '.join([str(study_id) for study_id in study_id_array])
 
     query_template = \
         ("SELECT ParticipantBarcode, Tumor_SampleBarcode, Tumor_AliquotBarcode, "
@@ -84,7 +87,9 @@ def build_query(project_name, dataset_name, table_name, gene, value_field, cohor
          "    SELECT sample_barcode "
          "    FROM [{project_name}:{cohort_dataset}.{cohort_table}] "
          "    WHERE cohort_id IN ({cohort_id_list})"
-         ") ")
+         "         AND (study_id IS NULL")
+
+    query_template += (" OR study_id IN ({study_id_list})))" if study_id_array is not None else "))")
 
     if value_field == 'num_mutations':
         value_field = 'count(*)'
@@ -94,7 +99,7 @@ def build_query(project_name, dataset_name, table_name, gene, value_field, cohor
     query = query_template.format(dataset_name=dataset_name, project_name=project_name, table_name=table_name,
                                   gene=gene, value_field=value_field,
                                   cohort_dataset=cohort_dataset, cohort_table=cohort_table,
-                                  cohort_id_list=cohort_id_stmt)
+                                  cohort_id_list=cohort_id_stmt, study_id_list=study_id_stmt)
 
     logging.debug("BQ_QUERY_GNAB: " + query)
     return query

--- a/bq_data_access/methylation_data.py
+++ b/bq_data_access/methylation_data.py
@@ -215,9 +215,12 @@ class METHFeatureProvider(FeatureDataProvider):
     def process_data_point(cls, data_point):
         return data_point['beta_value']
 
-    def build_query(self, project_name, dataset_name, table_name, feature_def, cohort_dataset, cohort_table, cohort_id_array):
+    def build_query(self, project_name, dataset_name, table_name, feature_def, cohort_dataset, cohort_table, cohort_id_array, study_id_array):
         # Generate the 'IN' statement string: (%s, %s, ..., %s)
         cohort_id_stmt = ', '.join([str(cohort_id) for cohort_id in cohort_id_array])
+        study_id_stmt = ''
+        if study_id_array is not None:
+            study_id_stmt = ', '.join([str(study_id) for study_id in study_id_array])
 
         query_template = \
             ("SELECT ParticipantBarcode, SampleBarcode, AliquotBarcode, beta_value "
@@ -227,12 +230,14 @@ class METHFeatureProvider(FeatureDataProvider):
              "    SELECT sample_barcode "
              "    FROM [{project_name}:{cohort_dataset}.{cohort_table}] "
              "    WHERE cohort_id IN ({cohort_id_list})"
-             ") ")
+             "         AND (study_id IS NULL")
+
+        query_template += (" OR study_id IN ({study_id_list})))" if study_id_array is not None else "))")
 
         query = query_template.format(dataset_name=dataset_name, project_name=project_name, table_name=table_name,
                                       probe_id=feature_def.probe, platform=feature_def.platform,
                                       cohort_dataset=cohort_dataset, cohort_table=cohort_table,
-                                      cohort_id_list=cohort_id_stmt)
+                                      cohort_id_list=cohort_id_stmt, study_id_list=study_id_stmt)
 
         logging.debug("BQ_QUERY_METH: " + query)
         return query

--- a/bq_data_access/mirna_data.py
+++ b/bq_data_access/mirna_data.py
@@ -136,9 +136,12 @@ class MIRNFeatureProvider(FeatureDataProvider):
     def process_data_point(cls, data_point):
         return data_point['value']
 
-    def build_query(self, project_name, dataset_name, table_name, feature_def, cohort_dataset, cohort_table, cohort_id_array):
+    def build_query(self, project_name, dataset_name, table_name, feature_def, cohort_dataset, cohort_table, cohort_id_array, study_id_array):
         # Generate the 'IN' statement string: (%s, %s, ..., %s)
         cohort_id_stmt = ', '.join([str(cohort_id) for cohort_id in cohort_id_array])
+        study_id_stmt = ''
+        if study_id_array is not None:
+            study_id_stmt = ', '.join([str(study_id) for study_id in study_id_array])
 
         query_template = \
             ("SELECT ParticipantBarcode, SampleBarcode, AliquotBarcode, {value_field} AS value, {mirna_name_field} "
@@ -156,13 +159,16 @@ class MIRNFeatureProvider(FeatureDataProvider):
              "    SELECT sample_barcode "
              "    FROM [{project_name}:{cohort_dataset}.{cohort_table}] "
              "    WHERE cohort_id IN ({cohort_id_list})"
-             ") ")
+             "         AND (study_id IS NULL")
+
+        query_template += (" OR study_id IN ({study_id_list})))" if study_id_array is not None else "))")
+
         query = query_template.format(dataset_name=dataset_name, project_name=project_name, table_name=table_name,
                                       mirna_name_field=mirna_name_field, mirna_name=feature_def.mirna_name,
                                       platform=feature_def.platform,
                                       value_field=feature_def.value_field,
                                       cohort_dataset=cohort_dataset, cohort_table=cohort_table,
-                                      cohort_id_list=cohort_id_stmt)
+                                      cohort_id_list=cohort_id_stmt, study_id_list=study_id_stmt)
 
         logging.debug("BQ_QUERY_MIRN: " + query)
         return query

--- a/bq_data_access/mrna_data.py
+++ b/bq_data_access/mrna_data.py
@@ -85,9 +85,12 @@ def get_table_info(table_id):
 
     return table_info
 
-def build_query(project_name, dataset_name, table_name, gene_symbol, value_field, cohort_dataset, cohort_table, cohort_id_array):
+def build_query(project_name, dataset_name, table_name, gene_symbol, value_field, cohort_dataset, cohort_table, cohort_id_array, study_id_array):
     # Generate the 'IN' statement string: (%s, %s, ..., %s)
     cohort_id_stmt = ', '.join([str(cohort_id) for cohort_id in cohort_id_array])
+    study_id_stmt = ''
+    if study_id_array is not None:
+        study_id_stmt = ', '.join([str(study_id) for study_id in study_id_array])
 
     query_template = \
         ("SELECT ParticipantBarcode AS patient_id, SampleBarcode AS sample_id, AliquotBarcode AS aliquot_id, {value_field} AS value "
@@ -97,12 +100,14 @@ def build_query(project_name, dataset_name, table_name, gene_symbol, value_field
          "    SELECT sample_barcode "
          "    FROM [{project_name}:{cohort_dataset}.{cohort_table}] "
          "    WHERE cohort_id IN ({cohort_id_list})"
-         ") ")
+         "         AND (study_id IS NULL")
+
+    query_template += (" OR study_id IN ({study_id_list})))" if study_id_array is not None else "))")
 
     query = query_template.format(dataset_name=dataset_name, project_name=project_name, table_name=table_name,
                                   gene_symbol=gene_symbol, value_field=value_field,
                                   cohort_dataset=cohort_dataset, cohort_table=cohort_table,
-                                  cohort_id_list=cohort_id_stmt)
+                                  cohort_id_list=cohort_id_stmt, study_id_list=study_id_stmt)
 
     logging.debug("BQ_QUERY_GEXP: " + query)
     return query

--- a/bq_data_access/protein_data.py
+++ b/bq_data_access/protein_data.py
@@ -83,9 +83,12 @@ class RPPAFeatureProvider(FeatureDataProvider):
     def process_data_point(cls, data_point):
         return data_point['value']
 
-    def build_query(self, project_name, dataset_name, table_name, feature_def,  cohort_dataset, cohort_table, cohort_id_array):
+    def build_query(self, project_name, dataset_name, table_name, feature_def,  cohort_dataset, cohort_table, cohort_id_array, study_id_array):
         # Generate the 'IN' statement string: (%s, %s, ..., %s)
         cohort_id_stmt = ', '.join([str(cohort_id) for cohort_id in cohort_id_array])
+        study_id_stmt = ''
+        if study_id_array is not None:
+            study_id_stmt = ', '.join([str(study_id) for study_id in study_id_array])
 
         query_template = \
             ("SELECT ParticipantBarcode, SampleBarcode, AliquotBarcode, protein_expression AS value "
@@ -95,12 +98,14 @@ class RPPAFeatureProvider(FeatureDataProvider):
              "    SELECT sample_barcode "
              "    FROM [{project_name}:{cohort_dataset}.{cohort_table}] "
              "    WHERE cohort_id IN ({cohort_id_list})"
-             ") ")
+             "         AND (study_id IS NULL")
+
+        query_template += (" OR study_id IN ({study_id_list})))" if study_id_array is not None else "))")
 
         query = query_template.format(dataset_name=dataset_name, project_name=project_name, table_name=table_name,
                                       gene=feature_def.gene, protein=feature_def.protein_name,
                                       cohort_dataset=cohort_dataset, cohort_table=cohort_table,
-                                      cohort_id_list=cohort_id_stmt)
+                                      cohort_id_list=cohort_id_stmt, study_id_list=study_id_stmt)
 
         logging.debug("BQ_QUERY_RPPA: " + query)
         return query

--- a/bq_data_access/seqpeek_maf_data.py
+++ b/bq_data_access/seqpeek_maf_data.py
@@ -32,9 +32,12 @@ class SeqPeekDataProvider(GNABFeatureProvider):
     def process_data_point(cls, data_point):
         return str(data_point['value'])
 
-    def build_query(self, project_name, dataset_name, table_name, feature_def, cohort_dataset, cohort_table, cohort_id_array):
+    def build_query(self, project_name, dataset_name, table_name, feature_def, cohort_dataset, cohort_table, cohort_id_array, study_id_array):
         # Generate the 'IN' statement string: (%s, %s, ..., %s)
         cohort_id_stmt = ', '.join([str(cohort_id) for cohort_id in cohort_id_array])
+        study_id_stmt = ''
+        if study_id_array is not None:
+            study_id_stmt = ', '.join([str(study_id) for study_id in study_id_array])
 
         query_template = \
             ("SELECT ParticipantBarcode, Tumor_SampleBarcode, Tumor_AliquotBarcode, "
@@ -48,12 +51,14 @@ class SeqPeekDataProvider(GNABFeatureProvider):
              "    SELECT sample_barcode "
              "    FROM [{project_name}:{cohort_dataset}.{cohort_table}] "
              "    WHERE cohort_id IN ({cohort_id_list})"
-             ") ")
+             "         AND (study_id IS NULL")
+
+        query_template += (" OR study_id IN ({study_id_list})))" if study_id_array is not None else "))")
 
         query = query_template.format(dataset_name=dataset_name, project_name=project_name, table_name=table_name,
                                       gene=feature_def.gene,
                                       cohort_dataset=cohort_dataset, cohort_table=cohort_table,
-                                      cohort_id_list=cohort_id_stmt)
+                                      cohort_id_list=cohort_id_stmt, study_id_list=study_id_stmt)
 
         logging.debug("BQ_QUERY_SEQPEEK: " + query)
         return query


### PR DESCRIPTION
- When ISB-CGC BQ data is being plotted, the cohort samples queried will be checked for proper study inheritance (or null) prior to being pulled from the BQ tables; this will ensure user data which shares the same sample barcodes but is NOT an extension of ISB-CGC data will not be erroneously plotted using ISB-CGC data.

**Note:** Requires #68 from Common and for the sproc to be added to the database; I've done the later for mvm and test