### PR TITLE
fix problem with duplicate barcodes

### DIFF
--- a/api_3/patients_get_helper.py
+++ b/api_3/patients_get_helper.py
@@ -39,20 +39,22 @@ class CasesGetQueryBuilder(object):
 
         sample_query_str = 'select sample_barcode ' \
                            'from {}_metadata_biospecimen ' \
-                           'where case_barcode=%s'.format(program)
+                           'where case_barcode=%s ' \
+                           'group by sample_barcode ' \
+                           'order by sample_barcode'.format(program)
 
         aliquot_query_str = ''
         for genomic_build in genomic_builds:
             part_aliquot_query_str = 'select aliquot_barcode ' \
                                 'from {}_metadata_data_{} ' \
                                 'where case_barcode=%s and aliquot_barcode is not null ' \
-                                'group by aliquot_barcode'.format(program, genomic_build)
+                                'group by aliquot_barcode ' \
+                                'order by aliquot_barcode'.format(program, genomic_build)
             if 0 < len(aliquot_query_str):
                 aliquot_query_str += ' union '
             aliquot_query_str += part_aliquot_query_str
 
         return clinical_query_str, sample_query_str, aliquot_query_str
-
 
 class CasesGetHelper(remote.Service):
 

--- a/api_3/users_get_common.py
+++ b/api_3/users_get_common.py
@@ -65,13 +65,12 @@ class UserGetAPICommon(remote.Service):
                 # FIND ALL DATASETS USER HAS ACCESS TO
                 user_auth_datasets = AuthorizedDataset.objects.filter(id__in=UserAuthorizedDatasets.objects.filter(nih_user_id=nih_user.id).values_list('authorized_dataset', flat=True))
                 for dataset in user_auth_datasets:
-                    ad = AuthorizedDataset.objects.get(whitelist_id=dataset.dataset_id)
-                    if program in ad.name:
+                    if program in dataset.name:
                         authorized = True
                         allowed = True
                 if not allowed:
                     das = DatasetAccessSupportFactory.from_webapp_django_settings()
-                    authorized_datasets = das.get_datasets_for_era_login(user_email)
+                    authorized_datasets = das.get_datasets_for_era_login(nih_user.NIH_username)
                     for dataset in authorized_datasets:
                         try:
                             ad = AuthorizedDataset.objects.get(whitelist_id=dataset.dataset_id)


### PR DESCRIPTION
the case.get endpoint was returning duplicate sample_barcodes because the sql needed a missing group by to collapse the legacy and current entries into one.  resolves isb-cgc/software-engineering-coordination#2017