### PR TITLE
another attempt to differentiate the apis

### DIFF
--- a/api_3/isb_cgc_api_CCLE/isb_cgc_api_helpers.py
+++ b/api_3/isb_cgc_api_CCLE/isb_cgc_api_helpers.py
@@ -23,5 +23,6 @@ ISB_CGC_CCLE_Endpoints = endpoints.api(name='isb_cgc_ccle_api', version='v3',
                                   description="Get information about cohorts, cases, and samples for CCLE. Create cohorts.",
                                   allowed_client_ids=[INSTALLED_APP_CLIENT_ID, endpoints.API_EXPLORER_CLIENT_ID,
                                                       settings.WEB_CLIENT_ID],
+                                  package_path='ccle',
                                   documentation='http://isb-cancer-genomics-cloud.readthedocs.io/en/latest/sections/progapi/Programmatic-API.html#isb-cgc-api-v3',
                                   title="ISB-CGC CCLE API")

--- a/api_3/isb_cgc_api_TARGET/isb_cgc_api_helpers.py
+++ b/api_3/isb_cgc_api_TARGET/isb_cgc_api_helpers.py
@@ -23,5 +23,6 @@ ISB_CGC_TARGET_Endpoints = endpoints.api(name='isb_cgc_target_api', version='v3'
                                   description="Get information about cohorts, cases, and samples for TARGET. Create cohorts.",
                                   allowed_client_ids=[INSTALLED_APP_CLIENT_ID, endpoints.API_EXPLORER_CLIENT_ID,
                                                       settings.WEB_CLIENT_ID],
+                                  package_path='target',
                                   documentation='http://isb-cancer-genomics-cloud.readthedocs.io/en/latest/sections/progapi/Programmatic-API.html#isb-cgc-api-v3',
                                   title="ISB-CGC TARGET API")

--- a/api_3/isb_cgc_api_TCGA/isb_cgc_api_helpers.py
+++ b/api_3/isb_cgc_api_TCGA/isb_cgc_api_helpers.py
@@ -23,5 +23,6 @@ ISB_CGC_TCGA_Endpoints = endpoints.api(name='isb_cgc_tcga_api', version='v3',
                                   description="Get information about cohorts, cases, and samples for TCGA. Create cohorts.",
                                   allowed_client_ids=[INSTALLED_APP_CLIENT_ID, endpoints.API_EXPLORER_CLIENT_ID,
                                                       settings.WEB_CLIENT_ID],
+                                  package_path='tcga',
                                   documentation='http://isb-cancer-genomics-cloud.readthedocs.io/en/latest/sections/progapi/Programmatic-API.html#isb-cgc-api-v3',
                                   title="ISB-CGC TCGA API")

--- a/cgc_api.py
+++ b/cgc_api.py
@@ -16,77 +16,63 @@ limitations under the License.
  
 """
 import endpoints
-# 
-# from api_3.isb_cgc_api.cohorts_delete import CohortsDeleteAPI
-# from api_3.isb_cgc_api.cohorts_get import CohortsGetAPI
-# from api_3.isb_cgc_api.cohorts_list import CohortsListAPI
-# from api_3.isb_cgc_api.cohorts_cloudstoragefilepaths import CohortsCloudStorageFilePathsAPI
-# 
-# from api_3.isb_cgc_api_TCGA.cohorts_preview import TCGA_CohortsPreviewAPI
-# from api_3.isb_cgc_api_TCGA.cohorts_create import TCGA_CohortsCreateAPI
-# from api_3.isb_cgc_api_TCGA.patients_get import TCGA_CasesGetAPI
-# from api_3.isb_cgc_api_TCGA.patients_annotations import TCGA_CasesAnnotationAPI
-# from api_3.isb_cgc_api_TCGA.samples_get import TCGA_SamplesGetAPI
-# from api_3.isb_cgc_api_TCGA.samples_cloudstoragefilepaths import TCGA_SamplesCloudStorageFilePathsAPI
-# from api_3.isb_cgc_api_TCGA.samples_annotations import TCGA_SamplesAnnotationAPI
-# from api_3.isb_cgc_api_TCGA.aliquots_annotations import TCGA_AliquotsAnnotationAPI
-# from api_3.isb_cgc_api_TCGA.users_get import TCGA_UserGetAPI
-# 
-# from api_3.isb_cgc_api_TARGET.cohorts_preview import TARGET_CohortsPreviewAPI
-# from api_3.isb_cgc_api_TARGET.cohorts_create import TARGET_CohortsCreateAPI
-# from api_3.isb_cgc_api_TARGET.patients_get import TARGET_CasesGetAPI
-# from api_3.isb_cgc_api_TARGET.samples_get import TARGET_SamplesGetAPI
-# from api_3.isb_cgc_api_TARGET.samples_cloudstoragefilepaths import TARGET_SamplesCloudStorageFilePathsAPI
-# from api_3.isb_cgc_api_TARGET.users_get import TARGET_UserGetAPI
-# 
-# from api_3.isb_cgc_api_CCLE.cohorts_preview import CCLE_CohortsPreviewAPI
-# from api_3.isb_cgc_api_CCLE.cohorts_create import CCLE_CohortsCreateAPI
-# from api_3.isb_cgc_api_CCLE.patients_get import CCLE_CasesGetAPI
-# from api_3.isb_cgc_api_CCLE.samples_get import CCLE_SamplesGetAPI
-# from api_3.isb_cgc_api_CCLE.samples_cloudstoragefilepaths import CCLE_SamplesCloudStorageFilePathsAPI
-# 
-# package = 'isb-cgc-api'
-# 
-# APPLICATION = endpoints.api_server([
-#     CohortsDeleteAPI,
-#     CohortsGetAPI,
-#     CohortsListAPI,
-#     CohortsCloudStorageFilePathsAPI,
-# 
-#     TCGA_CohortsPreviewAPI,
-#     TCGA_CohortsCreateAPI,
-#     TCGA_CasesGetAPI,
-#     TCGA_CasesAnnotationAPI,
-#     TCGA_SamplesGetAPI,
-#     TCGA_SamplesCloudStorageFilePathsAPI,
-#     TCGA_SamplesAnnotationAPI,
-#     TCGA_AliquotsAnnotationAPI,
-#     TCGA_UserGetAPI,
-#         
-#     TARGET_CohortsPreviewAPI,
-#     TARGET_CohortsCreateAPI,
-#     TARGET_CasesGetAPI,
-#     TARGET_SamplesGetAPI,
-#     TARGET_SamplesCloudStorageFilePathsAPI,
-#     TARGET_UserGetAPI,
-#         
-#     CCLE_CohortsPreviewAPI,
-#     CCLE_CohortsCreateAPI,
-#     CCLE_CasesGetAPI,
-#     CCLE_SamplesGetAPI,
-#     CCLE_SamplesCloudStorageFilePathsAPI
-# ])
-
-from api_3.isb_cgc_api.isb_cgc_api_helpers import ISB_CGC_Endpoints
-from api_3.isb_cgc_api_CCLE.isb_cgc_api_helpers import ISB_CGC_CCLE_Endpoints
-from api_3.isb_cgc_api_TARGET.isb_cgc_api_helpers import ISB_CGC_TARGET_Endpoints
-from api_3.isb_cgc_api_TCGA.isb_cgc_api_helpers import ISB_CGC_TCGA_Endpoints
-
+ 
+from api_3.isb_cgc_api.cohorts_delete import CohortsDeleteAPI
+from api_3.isb_cgc_api.cohorts_get import CohortsGetAPI
+from api_3.isb_cgc_api.cohorts_list import CohortsListAPI
+from api_3.isb_cgc_api.cohorts_cloudstoragefilepaths import CohortsCloudStorageFilePathsAPI
+ 
+from api_3.isb_cgc_api_TCGA.cohorts_preview import TCGA_CohortsPreviewAPI
+from api_3.isb_cgc_api_TCGA.cohorts_create import TCGA_CohortsCreateAPI
+from api_3.isb_cgc_api_TCGA.patients_get import TCGA_CasesGetAPI
+from api_3.isb_cgc_api_TCGA.patients_annotations import TCGA_CasesAnnotationAPI
+from api_3.isb_cgc_api_TCGA.samples_get import TCGA_SamplesGetAPI
+from api_3.isb_cgc_api_TCGA.samples_cloudstoragefilepaths import TCGA_SamplesCloudStorageFilePathsAPI
+from api_3.isb_cgc_api_TCGA.samples_annotations import TCGA_SamplesAnnotationAPI
+from api_3.isb_cgc_api_TCGA.aliquots_annotations import TCGA_AliquotsAnnotationAPI
+from api_3.isb_cgc_api_TCGA.users_get import TCGA_UserGetAPI
+ 
+from api_3.isb_cgc_api_TARGET.cohorts_preview import TARGET_CohortsPreviewAPI
+from api_3.isb_cgc_api_TARGET.cohorts_create import TARGET_CohortsCreateAPI
+from api_3.isb_cgc_api_TARGET.patients_get import TARGET_CasesGetAPI
+from api_3.isb_cgc_api_TARGET.samples_get import TARGET_SamplesGetAPI
+from api_3.isb_cgc_api_TARGET.samples_cloudstoragefilepaths import TARGET_SamplesCloudStorageFilePathsAPI
+from api_3.isb_cgc_api_TARGET.users_get import TARGET_UserGetAPI
+ 
+from api_3.isb_cgc_api_CCLE.cohorts_preview import CCLE_CohortsPreviewAPI
+from api_3.isb_cgc_api_CCLE.cohorts_create import CCLE_CohortsCreateAPI
+from api_3.isb_cgc_api_CCLE.patients_get import CCLE_CasesGetAPI
+from api_3.isb_cgc_api_CCLE.samples_get import CCLE_SamplesGetAPI
+from api_3.isb_cgc_api_CCLE.samples_cloudstoragefilepaths import CCLE_SamplesCloudStorageFilePathsAPI
+ 
 package = 'isb-cgc-api'
-
+ 
 APPLICATION = endpoints.api_server([
-    ISB_CGC_Endpoints,
-    ISB_CGC_CCLE_Endpoints,
-    ISB_CGC_TARGET_Endpoints,
-    ISB_CGC_TCGA_Endpoints
+    CohortsDeleteAPI,
+    CohortsGetAPI,
+    CohortsListAPI,
+    CohortsCloudStorageFilePathsAPI,
+ 
+    TCGA_CohortsPreviewAPI,
+    TCGA_CohortsCreateAPI,
+    TCGA_CasesGetAPI,
+    TCGA_CasesAnnotationAPI,
+    TCGA_SamplesGetAPI,
+    TCGA_SamplesCloudStorageFilePathsAPI,
+    TCGA_SamplesAnnotationAPI,
+    TCGA_AliquotsAnnotationAPI,
+    TCGA_UserGetAPI,
+         
+    TARGET_CohortsPreviewAPI,
+    TARGET_CohortsCreateAPI,
+    TARGET_CasesGetAPI,
+    TARGET_SamplesGetAPI,
+    TARGET_SamplesCloudStorageFilePathsAPI,
+    TARGET_UserGetAPI,
+         
+    CCLE_CohortsPreviewAPI,
+    CCLE_CohortsCreateAPI,
+    CCLE_CasesGetAPI,
+    CCLE_SamplesGetAPI,
+    CCLE_SamplesCloudStorageFilePathsAPI
 ])


### PR DESCRIPTION
reverted last change, didn't seem to work despite google's documentation.  used package_path for api definitions which hopefully will distinguish them.