### PR TITLE
Deployment fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dist/
 downloads/
 eggs/
 lib/
+ISB-CGC-Common/
 lib64/
 parts/
 sdist/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,19 @@
-requests==2.3.0
-django==1.11.10
+requests==2.10.0
 ecdsa==0.13
 google-api-python-client==1.6.1
 httplib2==0.9.2
 oauth2client==3.0.0
 python-openid==2.2.5
 pyasn1==0.4.1
-pytz==2015.7
 requests-oauthlib==0.7.0
 rsa==3.2
 simplejson==3.8.1
 six==1.10.0  #1.5.2
-uritemplate==0.6
+uritemplate==3.0.0
 GoogleAppEngineCloudStorageClient==1.9.22.1
 django-dotenv==1.4.2
 django-finalware==1.0.0
 django-allauth==0.35.0
 jsonschema==2.6.0
 enum34==1.1.6
+google-endpoints==4.0.0

--- a/shell/install-deps.sh
+++ b/shell/install-deps.sh
@@ -31,8 +31,6 @@ echo "Dependencies Installed "
 # Install PIP + Dependencies
 echo "Installing Python Libraries..."
 curl --silent https://bootstrap.pypa.io/get-pip.py | python
-# If we are in Frameworks 2.0, uncomment this and remove the endpoints entry from the libraries: section in the app.yaml
-pip install -t lib google-endpoints --ignore-installed --upgrade
 pip install -q -r ${HOMEROOT}/requirements.txt -t ${HOMEROOT}/lib --upgrade --only-binary all
 echo "Libraries Installed"
 


### PR DESCRIPTION
-> Move some requirements into the app.yaml to save space in deployment (Django, pytz)
-> Upgrade some libs (requests, uritemplates)
-> Add ISB-CGC-Common to gitignore (enables local deployments)
-> Move Google Endpoints Python library to requirements.txt
-> dos2unix on shell