### PR TITLE
Sprint 28

### DIFF
--- a/api_3/isb_cgc_api_TCGA/cohorts_preview.py
+++ b/api_3/isb_cgc_api_TCGA/cohorts_preview.py
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import endpoints
+from protorpc import messages
 
 from api_3.cohort_create_preview_helper import CohortsPreviewHelper
 from api_3.isb_cgc_api_TCGA.isb_cgc_api_helpers import ISB_CGC_TCGA_Endpoints
@@ -23,7 +24,7 @@ from message_classes import MetadataRangesItem
 @ISB_CGC_TCGA_Endpoints.api_class(resource_name='cohorts')
 class TCGA_CohortsPreviewAPI(CohortsPreviewHelper):
 
-    POST_RESOURCE = endpoints.ResourceContainer(MetadataRangesItem)
+    POST_RESOURCE = endpoints.ResourceContainer(MetadataRangesItem, fields=messages.StringField(3))
 
     @endpoints.method(POST_RESOURCE, CohortsPreviewHelper.CohortCasesSamplesList, path='tcga/cohorts/preview', http_method='POST')
     def preview(self, request):


### PR DESCRIPTION
- Lack of Common filter will no longer cause no samples to show up
- Removed a few loglines
- There are no 'common' continuous numerics, so no reason to join those in