### PR TITLE
Sprint 28

### DIFF
--- a/api_3/isb_cgc_api/cohort_export.py
+++ b/api_3/isb_cgc_api/cohort_export.py
@@ -1,0 +1,156 @@
+"""
+
+Copyright 2018, Institute for Systems Biology
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import endpoints
+import logging
+import django
+from protorpc import remote, messages
+
+from django.core.signals import request_finished
+from django.contrib.auth.models import User as Django_User
+from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
+from django.conf import settings
+
+from api_3.isb_cgc_api.isb_cgc_api_helpers import ISB_CGC_Endpoints
+
+from cohorts.file_helpers import cohort_files
+from cohorts.models import Cohort_Perms
+from accounts.sa_utils import auth_dataset_whitelists_for_user
+
+BASE_URL = settings.BASE_URL
+
+logger = logging.getLogger(__name__)
+
+
+class CohortFilters(messages.Message):
+    program = messages.StringField(1, repeated=True)
+    disease_code = messages.StringField(2, repeated=True)
+    project_short_name = messages.StringField(8, repeated=True)
+
+
+class CohortExportResult(messages.Message):
+    message = messages.StringField(2),
+    export_dest = messages.StringField(1),
+    num_exported = message.IntegerField(3)
+
+
+class ExportDestinationType(messages.Enum):
+    BIG_QUERY=1,
+    CLOUD_STORAGE=2
+
+
+class ExportCohort(remote.Service):
+    POST_RESOURCE = endpoints.ResourceContainer(
+        cohort_id=messages.IntegerField(1, required=True),
+        filters=messages.MessageField(CohortFilters, 2),
+        destination_type=messages.EnumField(ExportDestinationType, 4, required=True),
+        destination=messages.StringField(3, required=True),
+    )
+
+    def validate_user(self, cohort_id):
+        user_email = None
+        user = None
+        if endpoints.get_current_user() is not None:
+            user_email = endpoints.get_current_user().email()
+        if user_email is None:
+            raise endpoints.UnauthorizedException(
+                "Authentication failed. Try signing in to {} to register "
+                "with the web application.".
+                format(BASE_URL))
+        django.setup()
+        try:
+            user = Django_User.objects.get(email=user_email)
+            Cohort_Perms.objects.get(cohort_id=cohort_id, user_id=user.id)
+        except ObjectDoesNotExist as e:
+            err_msg = "Error retrieving cohort {} for user {}: {}".format(cohort_id, user_email, e)
+            if 'Cohort_Perms' in e.message:
+                err_msg = "User {} does not have permissions on cohort {}.".format(user_email, cohort_id)
+            logger.exception(e)
+            raise endpoints.UnauthorizedException(err_msg)
+        finally:
+            request_finished.send(self)
+        return user
+
+    def export_cohort_file_manifest(self, request):
+        cohort_id = request.get_assigned_value('cohort_id')
+        export_result = CohortExportResult()
+
+        try:
+            user = self.validate_user(cohort_id)
+
+            filter_obj = request.get_assigned_value('filters') if 'filters' in [k.name for k in request.all_fields()] else None
+
+            inc_filters = {
+                filter.name: filter_obj.get_assigned_value(filter.name)
+                           for filter in filter_obj.all_fields()
+                           if filter_obj.get_assigned_value(filter.name)
+                } if filter_obj else {}
+
+            # Call export method
+
+        except Exception as e:
+            logger.exception(e)
+            raise endpoints.InternalServerErrorException("There was an error while processing your request.")
+
+        return export_result
+
+    def export_cohort(self, request):
+        cohort_id = request.get_assigned_value('cohort_id')
+        export_result = CohortExportResult()
+
+        try:
+            user = self.validate_user(cohort_id)
+
+            filter_obj = request.get_assigned_value('filters') if 'filters' in [k.name for k in request.all_fields()] else None
+
+            inc_filters = {
+                filter.name: filter_obj.get_assigned_value(filter.name)
+                           for filter in filter_obj.all_fields()
+                           if filter_obj.get_assigned_value(filter.name)
+                } if filter_obj else {}
+
+            # Call export method
+
+        except Exception as e:
+            logger.exception(e)
+            raise endpoints.InternalServerErrorException("There was an error while processing your request.")
+
+        return export_result
+
+
+@ISB_CGC_Endpoints.api_class(resource_name='cohorts')
+class CohortExportAPI(ExportCohort):
+
+    @endpoints.method(ExportCohort.POST_RESOURCE, CohortExportResult, http_method='POST', path='cohorts/{cohort_id}/export')
+    def export_cohort(self, request):
+        """
+        Takes a cohort id as a required parameter and returns cloud storage paths to files
+        associated with all the samples in that cohort, up to a default limit of 10,000 files.
+        Authentication is required. User must have READER or OWNER permissions on the cohort.
+        """
+        return super(CohortExportAPI, self).export_cohort(request)
+
+@ISB_CGC_Endpoints.api_class(resource_name='cohorts')
+class CohortExportFileManifestAPI(ExportCohort):
+
+    @endpoints.method(ExportCohort.POST_RESOURCE, CohortExportResult, http_method='POST', path='cohorts/{cohort_id}/export/file_manifest')
+    def export_cohort_file_manifest(self, request):
+        """
+        Takes a cohort id as a required parameter and returns cloud storage paths to files
+        associated with all the samples in that cohort, up to a default limit of 10,000 files.
+        Authentication is required. User must have READER or OWNER permissions on the cohort.
+        """
+        return super(CohortExportFileManifestAPI, self).export_cohort_file_manifest(request)

--- a/api_3/isb_cgc_api/cohort_file_manifest.py
+++ b/api_3/isb_cgc_api/cohort_file_manifest.py
@@ -141,8 +141,6 @@ class CohortFileManifest(remote.Service):
                            if filter_obj.get_assigned_value(filter.name)
                 } if filter_obj else {}
 
-            logger.info("inc_filters: {}".format(str(inc_filters)))
-
             response = cohort_files(cohort_id, user=user, inc_filters=inc_filters, **params)
 
             file_manifest = FileManifest()

--- a/api_3/isb_cgc_api/cohort_file_manifest.py
+++ b/api_3/isb_cgc_api/cohort_file_manifest.py
@@ -1,0 +1,188 @@
+"""
+
+Copyright 2018, Institute for Systems Biology
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import endpoints
+import logging
+import django
+from protorpc import remote, messages
+
+from django.core.signals import request_finished
+from django.contrib.auth.models import User as Django_User
+from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
+from django.conf import settings
+
+from api_3.isb_cgc_api.isb_cgc_api_helpers import ISB_CGC_Endpoints
+
+from cohorts.file_helpers import cohort_files
+from cohorts.models import Cohort_Perms
+from accounts.sa_utils import auth_dataset_whitelists_for_user
+
+BASE_URL = settings.BASE_URL
+
+logger = logging.getLogger(__name__)
+
+
+class FileDetail(messages.Message):
+    program = messages.StringField(1, required=True)
+    case_barcode = messages.StringField(2, required=True)
+    file_path = messages.StringField(3, required=True)
+    file_gdc_uuid = messages.StringField(4)
+    disease_code = messages.StringField(5, required=True)
+    experimental_strategy = messages.StringField(6)
+    platform = messages.StringField(7)
+    data_category = messages.StringField(8)
+    data_type = messages.StringField(9)
+    data_format = messages.StringField(10)
+    access = messages.StringField(11)
+    case_gdc_uuid = messages.StringField(12)
+    project_short_name = messages.StringField(13)
+
+
+class FileManifest(messages.Message):
+    files = messages.MessageField(FileDetail, 1, repeated=True)
+    total_file_count = messages.IntegerField(2, variant=messages.Variant.INT32)
+    files_retrieved = messages.IntegerField(3, variant=messages.Variant.INT32)
+
+
+class FileManifestFilters(messages.Message):
+    program = messages.StringField(1, repeated=True)
+    disease_code = messages.StringField(2, repeated=True)
+    experimental_strategy = messages.StringField(3, repeated=True)
+    platform = messages.StringField(4, repeated=True)
+    data_category = messages.StringField(5, repeated=True)
+    data_type = messages.StringField(6, repeated=True)
+    data_format = messages.StringField(7, repeated=True)
+    project_short_name = messages.StringField(8, repeated=True)
+
+
+class CohortFileManifest(remote.Service):
+    GET_RESOURCE = endpoints.ResourceContainer(
+        cohort_id=messages.IntegerField(1, required=True),
+        fetch_count=messages.IntegerField(2),
+        offset=messages.IntegerField(3),
+        genomic_build=messages.StringField(4),
+        do_filter_count=messages.BooleanField(6),
+        filters=messages.MessageField(FileManifestFilters, 5)
+    )
+
+    def validate_user(self, cohort_id):
+        user_email = None
+        user = None
+        if endpoints.get_current_user() is not None:
+            user_email = endpoints.get_current_user().email()
+        if user_email is None:
+            raise endpoints.UnauthorizedException(
+                "Authentication failed. Try signing in to {} to register "
+                "with the web application.".
+                format(BASE_URL))
+        django.setup()
+        try:
+            user = Django_User.objects.get(email=user_email)
+            Cohort_Perms.objects.get(cohort_id=cohort_id, user_id=user.id)
+        except ObjectDoesNotExist as e:
+            err_msg = "Error retrieving cohort {} for user {}: {}".format(cohort_id, user_email, e)
+            if 'Cohort_Perms' in e.message:
+                err_msg = "User {} does not have permissions on cohort {}.".format(user_email, cohort_id)
+            logger.exception(e)
+            raise endpoints.UnauthorizedException(err_msg)
+        finally:
+            request_finished.send(self)
+        return user
+
+    def file_manifest(self, request):
+        cohort_id = request.get_assigned_value('cohort_id')
+        file_manifest = None
+
+        try:
+            user = self.validate_user(cohort_id)
+            has_access = auth_dataset_whitelists_for_user(user.id)
+
+            params = {}
+
+            if request.get_assigned_value('offset'):
+                params['offset'] = request.get_assigned_value('offset')
+
+            if request.get_assigned_value('fetch_count'):
+                params['limit'] = request.get_assigned_value('fetch_count')
+            else:
+                params['limit'] = settings.MAX_FILE_LIST_REQUEST
+
+            if request.get_assigned_value('do_filter_count'):
+                params['do_filter_count'] = request.get_assigned_value('do_filter_count')
+
+            params['access'] = has_access
+
+            filter_obj = request.get_assigned_value('filters') or {}
+
+            inc_filters = {}
+
+            for filter in filter_obj.all_fields():
+                if filter_obj.get_assigned_value(filter.name):
+                    inc_filters[filter.name] = filter_obj.get_assigned_value(filter.name)
+
+            response = cohort_files(cohort_id, user=user, inc_filters=inc_filters, **params)
+
+            file_manifest = FileManifest()
+            files = []
+
+            for file in response['file_list']:
+                files.append(FileDetail(
+                    program=file['program'],
+                    case_barcode=file['case'],
+                    case_gdc_uuid=file['case_gdc_id'],
+                    file_path=file['cloudstorage_location'],
+                    file_gdc_uuid=file['file_gdc_id'],
+                    disease_code=file['disease_code'],
+                    project_short_name=file['project_short_name'],
+                    experimental_strategy=file['exp_strat'],
+                    platform=file['platform'],
+                    data_category=file['datacat'],
+                    data_type=file['datatype'],
+                    data_format=file['dataformat'],
+                    access=file['access']
+                ))
+
+            file_manifest.files = files
+            file_manifest.total_file_count = response['total_file_count']
+            file_manifest.files_retrieved = len(files)
+
+        except Exception as e:
+            logger.exception(e)
+            raise endpoints.InternalServerErrorException("There was an error while processing your request.")
+
+        return file_manifest
+
+
+@ISB_CGC_Endpoints.api_class(resource_name='cohorts')
+class CohortFileManifestAPI(CohortFileManifest):
+
+    @endpoints.method(CohortFileManifest.GET_RESOURCE, FileManifest, http_method='GET', path='cohorts/{cohort_id}/file_manifest')
+    def file_manifest(self, request):
+        """
+        Takes a cohort id as a required parameter and returns cloud storage paths to files
+        associated with all the samples in that cohort, up to a default limit of 10,000 files.
+        Authentication is required. User must have READER or OWNER permissions on the cohort.
+        """
+        return super(CohortFileManifestAPI, self).file_manifest(request)
+
+    @endpoints.method(CohortFileManifest.GET_RESOURCE, FileManifest, http_method='POST', path='cohorts/{cohort_id}/file_manifest')
+    def file_manifest_filtered(self, request):
+        """
+        Takes a cohort id as a required parameter and returns cloud storage paths to files
+        associated with all the samples in that cohort, up to a default limit of 10,000 files.
+        Authentication is required. User must have READER or OWNER permissions on the cohort.
+        """
+        return super(CohortFileManifestAPI, self).file_manifest(request)

--- a/api_3/isb_cgc_api/files_get_file_paths.py
+++ b/api_3/isb_cgc_api/files_get_file_paths.py
@@ -21,11 +21,13 @@ from api_3.isb_cgc_api.isb_cgc_api_helpers import ISB_CGC_Endpoints
 
 from api_3.api_helpers import sql_connection
 
+
 @ISB_CGC_Endpoints.api_class(resource_name='files')
 class FilesGetPath(remote.Service):
     GET_RESOURCE = endpoints.ResourceContainer(file_uuids=messages.StringField(1, repeated=True))
+
     class FilePaths(messages.Message):
-        paths = messages.StringField(1, repeated = True)
+        paths = messages.StringField(1, repeated=True)
 
     @endpoints.method(GET_RESOURCE, FilePaths, http_method='GET', path='file_paths')
     def get(self, request):
@@ -64,4 +66,3 @@ class FilesGetPath(remote.Service):
         filepaths = FilesGetPath.FilePaths()
         filepaths.paths = [item for sublist in uuid2paths.values() for item in sublist]
         return filepaths
-

--- a/api_3/isb_cgc_api/isb_cgc_api_helpers.py
+++ b/api_3/isb_cgc_api/isb_cgc_api_helpers.py
@@ -1,6 +1,6 @@
 """
 
-Copyright 2017, Institute for Systems Biology
+Copyright 2018, Institute for Systems Biology
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ from django.conf import settings
 INSTALLED_APP_CLIENT_ID = settings.INSTALLED_APP_CLIENT_ID
 
 ISB_CGC_Endpoints = endpoints.api(name='isb_cgc_api', version='v3',
-                                  description="Get information about cohorts for ISB-CGC. List, get, delete cohorts.",
+                                  description="Get information about cohorts for ISB-CGC. List, get, delete cohorts, and retrieve or export their file manifests.",
                                   allowed_client_ids=[INSTALLED_APP_CLIENT_ID, endpoints.API_EXPLORER_CLIENT_ID,
                                                       settings.WEB_CLIENT_ID],
                                   documentation='http://isb-cancer-genomics-cloud.readthedocs.io/en/latest/sections/progapi/Programmatic-API.html#isb-cgc-api-v3',

--- a/api_3/isb_cgc_api_CCLE/cohorts_create.py
+++ b/api_3/isb_cgc_api_CCLE/cohorts_create.py
@@ -22,7 +22,7 @@ from api_3.isb_cgc_api_CCLE.isb_cgc_api_helpers import ISB_CGC_CCLE_Endpoints
 from api_3.isb_cgc_api_CCLE.message_classes import MetadataRangesItem
 
 @ISB_CGC_CCLE_Endpoints.api_class(resource_name='cohorts')
-class CCLE_CohortsCreateAPI(CohortsCreateHelper):
+class CCLECohortsCreateAPI(CohortsCreateHelper):
     POST_RESOURCE = endpoints.ResourceContainer(MetadataRangesItem, name=messages.StringField(2, required=True))
 
     @endpoints.method(POST_RESOURCE, CreatedCohort, path='ccle/cohorts/create', http_method='POST')
@@ -34,4 +34,4 @@ class CCLE_CohortsCreateAPI(CohortsCreateHelper):
         of samples in that cohort.
         """
         self.program = 'CCLE'
-        return super(CCLE_CohortsCreateAPI, self).create(request)
+        return super(CCLECohortsCreateAPI, self).create(request)

--- a/api_3/isb_cgc_api_CCLE/cohorts_preview.py
+++ b/api_3/isb_cgc_api_CCLE/cohorts_preview.py
@@ -21,7 +21,7 @@ from api_3.isb_cgc_api_CCLE.isb_cgc_api_helpers import ISB_CGC_CCLE_Endpoints
 from message_classes import MetadataRangesItem
 
 @ISB_CGC_CCLE_Endpoints.api_class(resource_name='cohorts')
-class CCLE_CohortsPreviewAPI(CohortsPreviewHelper):
+class CCLECohortsPreviewAPI(CohortsPreviewHelper):
 
     POST_RESOURCE = endpoints.ResourceContainer(MetadataRangesItem)
 
@@ -34,4 +34,4 @@ class CCLE_CohortsPreviewAPI(CohortsPreviewHelper):
         Authentication is not required.
         """
         self.program = 'CCLE'
-        return super(CCLE_CohortsPreviewAPI, self).preview(request)
+        return super(CCLECohortsPreviewAPI, self).preview(request)

--- a/api_3/isb_cgc_api_CCLE/patients_get.py
+++ b/api_3/isb_cgc_api_CCLE/patients_get.py
@@ -28,7 +28,7 @@ class CaseDetails(messages.Message):
     aliquots = messages.StringField(3, repeated=True)
 
 @ISB_CGC_CCLE_Endpoints.api_class(resource_name='cases')
-class CCLE_CasesGetAPI(CasesGetHelper):
+class CCLECasesGetAPI(CasesGetHelper):
     @endpoints.method(CasesGetHelper.GET_RESOURCE, CaseDetails, path='ccle/cases/{case_barcode}', http_method='GET')
     def get(self, request):
         """
@@ -37,4 +37,4 @@ class CCLE_CasesGetAPI(CasesGetHelper):
         Takes a case barcode (*eg* ACC-MESO-1) as a required parameter.
         User does not need to be authenticated.
         """
-        return super(CCLE_CasesGetAPI, self).get(request, CaseDetails, MetadataItem, 'CCLE')
+        return super(CCLECasesGetAPI, self).get(request, CaseDetails, MetadataItem, 'CCLE')

--- a/api_3/isb_cgc_api_CCLE/samples_cloudstoragefilepaths.py
+++ b/api_3/isb_cgc_api_CCLE/samples_cloudstoragefilepaths.py
@@ -21,7 +21,7 @@ from api_3.isb_cgc_api_CCLE.isb_cgc_api_helpers import ISB_CGC_CCLE_Endpoints
 from api_3.cloudstoragefilepaths_helper import GCSFilePathList, SamplesCloudStorageFilePathsHelper
 
 @ISB_CGC_CCLE_Endpoints.api_class(resource_name='samples')
-class CCLE_SamplesCloudStorageFilePathsAPI(SamplesCloudStorageFilePathsHelper):
+class CCLESamplesCloudStorageFilePathsAPI(SamplesCloudStorageFilePathsHelper):
 
     @endpoints.method(SamplesCloudStorageFilePathsHelper.GET_RESOURCE, GCSFilePathList,
                       path='ccle/samples/{sample_barcode}/cloud_storage_file_paths', http_method='GET')
@@ -30,4 +30,4 @@ class CCLE_SamplesCloudStorageFilePathsAPI(SamplesCloudStorageFilePathsHelper):
         Takes a sample barcode as a required parameter and
         returns cloud storage paths to files associated with that sample.
         """
-        return super(CCLE_SamplesCloudStorageFilePathsAPI, self).cloud_storage_file_paths(request, 'CCLE')
+        return super(CCLESamplesCloudStorageFilePathsAPI, self).cloud_storage_file_paths(request, 'CCLE')

--- a/api_3/isb_cgc_api_CCLE/samples_get.py
+++ b/api_3/isb_cgc_api_CCLE/samples_get.py
@@ -31,7 +31,7 @@ class SampleDetails(messages.Message):
     data_details_count = messages.IntegerField(6, variant=messages.Variant.INT32)
 
 @ISB_CGC_CCLE_Endpoints.api_class(resource_name='samples')
-class CCLE_SamplesGetAPI(SamplesGetAPI):
+class CCLESamplesGetAPI(SamplesGetAPI):
     @endpoints.method(SamplesGetAPI.GET_RESOURCE, SampleDetails, path='ccle/samples/{sample_barcode}', http_method='GET')
     def get(self, request):
         """
@@ -40,4 +40,4 @@ class CCLE_SamplesGetAPI(SamplesGetAPI):
         the associated case barcode, a list of associated aliquots,
         and a list of "data_details" blocks describing each of the data files associated with this sample
         """
-        return super(CCLE_SamplesGetAPI, self).get(request, 'CCLE', SampleDetails, MetadataItem)
+        return super(CCLESamplesGetAPI, self).get(request, 'CCLE', SampleDetails, MetadataItem)

--- a/api_3/isb_cgc_api_TARGET/cohorts_create.py
+++ b/api_3/isb_cgc_api_TARGET/cohorts_create.py
@@ -22,7 +22,7 @@ from api_3.isb_cgc_api_TARGET.isb_cgc_api_helpers import ISB_CGC_TARGET_Endpoint
 from api_3.isb_cgc_api_TARGET.message_classes import MetadataRangesItem
 
 @ISB_CGC_TARGET_Endpoints.api_class(resource_name='cohorts')
-class TARGET_CohortsCreateAPI(CohortsCreateHelper):
+class TARGETCohortsCreateAPI(CohortsCreateHelper):
     POST_RESOURCE = endpoints.ResourceContainer(MetadataRangesItem, name=messages.StringField(2, required=True))
 
     @endpoints.method(POST_RESOURCE, CreatedCohort, path='target/cohorts/create', http_method='POST')
@@ -34,4 +34,4 @@ class TARGET_CohortsCreateAPI(CohortsCreateHelper):
         of samples in that cohort.
         """
         self.program = 'TARGET'
-        return super(TARGET_CohortsCreateAPI, self).create(request)
+        return super(TARGETCohortsCreateAPI, self).create(request)

--- a/api_3/isb_cgc_api_TARGET/cohorts_preview.py
+++ b/api_3/isb_cgc_api_TARGET/cohorts_preview.py
@@ -21,7 +21,7 @@ from api_3.isb_cgc_api_TARGET.isb_cgc_api_helpers import ISB_CGC_TARGET_Endpoint
 from message_classes import MetadataRangesItem
 
 @ISB_CGC_TARGET_Endpoints.api_class(resource_name='cohorts')
-class TARGET_CohortsPreviewAPI(CohortsPreviewHelper):
+class TARGETCohortsPreviewAPI(CohortsPreviewHelper):
 
     POST_RESOURCE = endpoints.ResourceContainer(MetadataRangesItem)
 
@@ -34,4 +34,4 @@ class TARGET_CohortsPreviewAPI(CohortsPreviewHelper):
         Authentication is not required.
         """
         self.program = 'TARGET'
-        return super(TARGET_CohortsPreviewAPI, self).preview(request)
+        return super(TARGETCohortsPreviewAPI, self).preview(request)

--- a/api_3/isb_cgc_api_TARGET/patients_get.py
+++ b/api_3/isb_cgc_api_TARGET/patients_get.py
@@ -28,7 +28,7 @@ class CaseDetails(messages.Message):
     aliquots = messages.StringField(3, repeated=True)
 
 @ISB_CGC_TARGET_Endpoints.api_class(resource_name='cases')
-class TARGET_CasesGetAPI(CasesGetHelper):
+class TARGETCasesGetAPI(CasesGetHelper):
     @endpoints.method(CasesGetHelper.GET_RESOURCE, CaseDetails, path='target/cases/{case_barcode}', http_method='GET')
     def get(self, request):
         """
@@ -37,4 +37,4 @@ class TARGET_CasesGetAPI(CasesGetHelper):
         Takes a case barcode (of length 16, *eg* TARGET-51-PALFYG) as a required parameter.
         User does not need to be authenticated.
         """
-        return super(TARGET_CasesGetAPI, self).get(request, CaseDetails, MetadataItem, 'TARGET')
+        return super(TARGETCasesGetAPI, self).get(request, CaseDetails, MetadataItem, 'TARGET')

--- a/api_3/isb_cgc_api_TARGET/samples_cloudstoragefilepaths.py
+++ b/api_3/isb_cgc_api_TARGET/samples_cloudstoragefilepaths.py
@@ -21,7 +21,7 @@ from api_3.isb_cgc_api_TARGET.isb_cgc_api_helpers import ISB_CGC_TARGET_Endpoint
 from api_3.cloudstoragefilepaths_helper import GCSFilePathList, SamplesCloudStorageFilePathsHelper
 
 @ISB_CGC_TARGET_Endpoints.api_class(resource_name='samples')
-class TARGET_SamplesCloudStorageFilePathsAPI(SamplesCloudStorageFilePathsHelper):
+class TARGETSamplesCloudStorageFilePathsAPI(SamplesCloudStorageFilePathsHelper):
 
     @endpoints.method(SamplesCloudStorageFilePathsHelper.GET_RESOURCE, GCSFilePathList,
                       path='target/samples/{sample_barcode}/cloud_storage_file_paths', http_method='GET')
@@ -30,4 +30,4 @@ class TARGET_SamplesCloudStorageFilePathsAPI(SamplesCloudStorageFilePathsHelper)
         Takes a sample barcode as a required parameter and
         returns cloud storage paths to files associated with that sample.
         """
-        return super(TARGET_SamplesCloudStorageFilePathsAPI, self).cloud_storage_file_paths(request, 'TARGET')
+        return super(TARGETSamplesCloudStorageFilePathsAPI, self).cloud_storage_file_paths(request, 'TARGET')

--- a/api_3/isb_cgc_api_TARGET/samples_get.py
+++ b/api_3/isb_cgc_api_TARGET/samples_get.py
@@ -31,7 +31,7 @@ class SampleDetails(messages.Message):
     data_details_count = messages.IntegerField(6, variant=messages.Variant.INT32)
 
 @ISB_CGC_TARGET_Endpoints.api_class(resource_name='samples')
-class TARGET_SamplesGetAPI(SamplesGetAPI):
+class TARGETSamplesGetAPI(SamplesGetAPI):
     @endpoints.method(SamplesGetAPI.GET_RESOURCE, SampleDetails, path='target/samples/{sample_barcode}', http_method='GET')
     def get(self, request):
         """
@@ -40,4 +40,4 @@ class TARGET_SamplesGetAPI(SamplesGetAPI):
         the associated case barcode, a list of associated aliquots,
         and a list of "data_details" blocks describing each of the data files associated with this sample
         """
-        return super(TARGET_SamplesGetAPI, self).get(request, 'TARGET', SampleDetails, MetadataItem)
+        return super(TARGETSamplesGetAPI, self).get(request, 'TARGET', SampleDetails, MetadataItem)

--- a/api_3/isb_cgc_api_TARGET/users_get.py
+++ b/api_3/isb_cgc_api_TARGET/users_get.py
@@ -22,11 +22,11 @@ from api_3.users_get_common import UserGetAPICommon, UserGetAPIReturnJSON
 from api_3.isb_cgc_api_TARGET.isb_cgc_api_helpers import ISB_CGC_TARGET_Endpoints
 
 @ISB_CGC_TARGET_Endpoints.api_class(resource_name='users')
-class TARGET_UserGetAPI(UserGetAPICommon):
+class TARGETUserGetAPI(UserGetAPICommon):
 
     @endpoints.method(message_types.VoidMessage, UserGetAPIReturnJSON, http_method='GET', path='target/users')
     def get(self, _):
         '''
         Returns the dbGaP authorization status of the user.
         '''
-        return super(TARGET_UserGetAPI, self).get('TARGET')
+        return super(TARGETUserGetAPI, self).get('TARGET')

--- a/api_3/isb_cgc_api_TCGA/aliquots_annotations.py
+++ b/api_3/isb_cgc_api_TCGA/aliquots_annotations.py
@@ -42,7 +42,7 @@ class AliquotsAnnotationsQueryBuilder(object):
         return 'select * from TCGA_metadata_data_HG19 where aliquot_barcode=%s '
 
 @ISB_CGC_TCGA_Endpoints.api_class(resource_name='aliquots')
-class TCGA_AliquotsAnnotationAPI(AnnotationAPI):
+class TCGAAliquotsAnnotationAPI(AnnotationAPI):
 
     GET_RESOURCE = endpoints.ResourceContainer(aliquot_barcode=messages.StringField(1, required=True),
                                                entity_type=messages.StringField(2, repeated=True))

--- a/api_3/isb_cgc_api_TCGA/cohorts_create.py
+++ b/api_3/isb_cgc_api_TCGA/cohorts_create.py
@@ -22,7 +22,7 @@ from api_3.isb_cgc_api_TCGA.isb_cgc_api_helpers import ISB_CGC_TCGA_Endpoints
 from api_3.isb_cgc_api_TCGA.message_classes import MetadataRangesItem
 
 @ISB_CGC_TCGA_Endpoints.api_class(resource_name='cohorts')
-class TCGA_CohortsCreateAPI(CohortsCreateHelper):
+class TCGACohortsCreateAPI(CohortsCreateHelper):
     POST_RESOURCE = endpoints.ResourceContainer(MetadataRangesItem, name=messages.StringField(2, required=True))
 
     @endpoints.method(POST_RESOURCE, CreatedCohort, path='tcga/cohorts/create', http_method='POST')
@@ -34,4 +34,4 @@ class TCGA_CohortsCreateAPI(CohortsCreateHelper):
         of samples in that cohort.
         """
         self.program = 'TCGA'
-        return super(TCGA_CohortsCreateAPI, self).create(request)
+        return super(TCGACohortsCreateAPI, self).create(request)

--- a/api_3/isb_cgc_api_TCGA/cohorts_preview.py
+++ b/api_3/isb_cgc_api_TCGA/cohorts_preview.py
@@ -22,7 +22,7 @@ from api_3.isb_cgc_api_TCGA.isb_cgc_api_helpers import ISB_CGC_TCGA_Endpoints
 from message_classes import MetadataRangesItem
 
 @ISB_CGC_TCGA_Endpoints.api_class(resource_name='cohorts')
-class TCGA_CohortsPreviewAPI(CohortsPreviewHelper):
+class TCGACohortsPreviewAPI(CohortsPreviewHelper):
 
     POST_RESOURCE = endpoints.ResourceContainer(MetadataRangesItem, fields=messages.StringField(3))
 
@@ -35,4 +35,4 @@ class TCGA_CohortsPreviewAPI(CohortsPreviewHelper):
         Authentication is not required.
         """
         self.program = 'TCGA'
-        return super(TCGA_CohortsPreviewAPI, self).preview(request)
+        return super(TCGACohortsPreviewAPI, self).preview(request)

--- a/api_3/isb_cgc_api_TCGA/patients_annotations.py
+++ b/api_3/isb_cgc_api_TCGA/patients_annotations.py
@@ -47,7 +47,7 @@ class CasesAnnotationsQueryBuilder(object):
         return query_str
 
 @ISB_CGC_TCGA_Endpoints.api_class(resource_name='cases')
-class TCGA_CasesAnnotationAPI(AnnotationAPI):
+class TCGACasesAnnotationAPI(AnnotationAPI):
 
     GET_RESOURCE = endpoints.ResourceContainer(case_barcode=messages.StringField(1, required=True),
                                                entity_type=messages.StringField(2, repeated=True))

--- a/api_3/isb_cgc_api_TCGA/patients_get.py
+++ b/api_3/isb_cgc_api_TCGA/patients_get.py
@@ -28,7 +28,7 @@ class CaseDetails(messages.Message):
     aliquots = messages.StringField(3, repeated=True)
 
 @ISB_CGC_TCGA_Endpoints.api_class(resource_name='cases')
-class TCGA_CasesGetAPI(CasesGetHelper):
+class TCGACasesGetAPI(CasesGetHelper):
     @endpoints.method(CasesGetHelper.GET_RESOURCE, CaseDetails, path='tcga/cases/{case_barcode}', http_method='GET')
     def get(self, request):
         """
@@ -37,4 +37,4 @@ class TCGA_CasesGetAPI(CasesGetHelper):
         Takes a case barcode (of length 12, *eg* TCGA-B9-7268) as a required parameter.
         User does not need to be authenticated.
         """
-        return super(TCGA_CasesGetAPI, self).get(request, CaseDetails, MetadataItem, 'TCGA')
+        return super(TCGACasesGetAPI, self).get(request, CaseDetails, MetadataItem, 'TCGA')

--- a/api_3/isb_cgc_api_TCGA/samples_annotations.py
+++ b/api_3/isb_cgc_api_TCGA/samples_annotations.py
@@ -48,7 +48,7 @@ class SamplesAnnotationsQueryBuilder(object):
 
 
 @ISB_CGC_TCGA_Endpoints.api_class(resource_name='samples')
-class TCGA_SamplesAnnotationAPI(AnnotationAPI):
+class TCGASamplesAnnotationAPI(AnnotationAPI):
 
     GET_RESOURCE = endpoints.ResourceContainer(sample_barcode=messages.StringField(1, required=True),
                                                entity_type=messages.StringField(2, repeated=True))

--- a/api_3/isb_cgc_api_TCGA/samples_cloudstoragefilepaths.py
+++ b/api_3/isb_cgc_api_TCGA/samples_cloudstoragefilepaths.py
@@ -21,7 +21,7 @@ from api_3.isb_cgc_api_TCGA.isb_cgc_api_helpers import ISB_CGC_TCGA_Endpoints
 from api_3.cloudstoragefilepaths_helper import GCSFilePathList, SamplesCloudStorageFilePathsHelper
 
 @ISB_CGC_TCGA_Endpoints.api_class(resource_name='samples')
-class TCGA_SamplesCloudStorageFilePathsAPI(SamplesCloudStorageFilePathsHelper):
+class TCGASamplesCloudStorageFilePathsAPI(SamplesCloudStorageFilePathsHelper):
 
     @endpoints.method(SamplesCloudStorageFilePathsHelper.GET_RESOURCE, GCSFilePathList,
                       path='tcga/samples/{sample_barcode}/cloud_storage_file_paths', http_method='GET')
@@ -30,4 +30,4 @@ class TCGA_SamplesCloudStorageFilePathsAPI(SamplesCloudStorageFilePathsHelper):
         Takes a sample barcode as a required parameter and
         returns cloud storage paths to files associated with that sample.
         """
-        return super(TCGA_SamplesCloudStorageFilePathsAPI, self).cloud_storage_file_paths(request, 'TCGA')
+        return super(TCGASamplesCloudStorageFilePathsAPI, self).cloud_storage_file_paths(request, 'TCGA')

--- a/api_3/isb_cgc_api_TCGA/samples_get.py
+++ b/api_3/isb_cgc_api_TCGA/samples_get.py
@@ -31,7 +31,7 @@ class SampleDetails(messages.Message):
     data_details_count = messages.IntegerField(6, variant=messages.Variant.INT32)
 
 @ISB_CGC_TCGA_Endpoints.api_class(resource_name='samples')
-class TCGA_SamplesGetAPI(SamplesGetAPI):
+class TCGASamplesGetAPI(SamplesGetAPI):
     @endpoints.method(SamplesGetAPI.GET_RESOURCE, SampleDetails, path='tcga/samples/{sample_barcode}', http_method='GET')
     def get(self, request):
         """
@@ -40,4 +40,4 @@ class TCGA_SamplesGetAPI(SamplesGetAPI):
         the associated case barcode, a list of associated aliquots,
         and a list of "data_details" blocks describing each of the data files associated with this sample
         """
-        return super(TCGA_SamplesGetAPI, self).get(request, 'TCGA', SampleDetails, MetadataItem)
+        return super(TCGASamplesGetAPI, self).get(request, 'TCGA', SampleDetails, MetadataItem)

--- a/api_3/isb_cgc_api_TCGA/users_get.py
+++ b/api_3/isb_cgc_api_TCGA/users_get.py
@@ -22,11 +22,11 @@ from api_3.users_get_common import UserGetAPICommon, UserGetAPIReturnJSON
 from api_3.isb_cgc_api_TCGA.isb_cgc_api_helpers import ISB_CGC_TCGA_Endpoints
 
 @ISB_CGC_TCGA_Endpoints.api_class(resource_name='users')
-class TCGA_UserGetAPI(UserGetAPICommon):
+class TCGAUserGetAPI(UserGetAPICommon):
 
     @endpoints.method(message_types.VoidMessage, UserGetAPIReturnJSON, http_method='GET', path='tcga/users')
     def get(self, _):
         '''
         Returns the dbGaP authorization status of the user.
         '''
-        return super(TCGA_UserGetAPI, self).get('TCGA')
+        return super(TCGAUserGetAPI, self).get('TCGA')

--- a/cgc_api.py
+++ b/cgc_api.py
@@ -24,28 +24,28 @@ from api_3.isb_cgc_api.cohorts_cloudstoragefilepaths import CohortsCloudStorageF
 from api_3.isb_cgc_api.files_get_file_paths import FilesGetPath
 from api_3.isb_cgc_api.cohort_file_manifest import CohortFileManifestAPI
  
-from api_3.isb_cgc_api_TCGA.cohorts_preview import TCGA_CohortsPreviewAPI
-from api_3.isb_cgc_api_TCGA.cohorts_create import TCGA_CohortsCreateAPI
-from api_3.isb_cgc_api_TCGA.patients_get import TCGA_CasesGetAPI
-from api_3.isb_cgc_api_TCGA.patients_annotations import TCGA_CasesAnnotationAPI
-from api_3.isb_cgc_api_TCGA.samples_get import TCGA_SamplesGetAPI
-from api_3.isb_cgc_api_TCGA.samples_cloudstoragefilepaths import TCGA_SamplesCloudStorageFilePathsAPI
-from api_3.isb_cgc_api_TCGA.samples_annotations import TCGA_SamplesAnnotationAPI
-from api_3.isb_cgc_api_TCGA.aliquots_annotations import TCGA_AliquotsAnnotationAPI
-from api_3.isb_cgc_api_TCGA.users_get import TCGA_UserGetAPI
+from api_3.isb_cgc_api_TCGA.cohorts_preview import TCGACohortsPreviewAPI
+from api_3.isb_cgc_api_TCGA.cohorts_create import TCGACohortsCreateAPI
+from api_3.isb_cgc_api_TCGA.patients_get import TCGACasesGetAPI
+from api_3.isb_cgc_api_TCGA.patients_annotations import TCGACasesAnnotationAPI
+from api_3.isb_cgc_api_TCGA.samples_get import TCGASamplesGetAPI
+from api_3.isb_cgc_api_TCGA.samples_cloudstoragefilepaths import TCGASamplesCloudStorageFilePathsAPI
+from api_3.isb_cgc_api_TCGA.samples_annotations import TCGASamplesAnnotationAPI
+from api_3.isb_cgc_api_TCGA.aliquots_annotations import TCGAAliquotsAnnotationAPI
+from api_3.isb_cgc_api_TCGA.users_get import TCGAUserGetAPI
  
-from api_3.isb_cgc_api_TARGET.cohorts_preview import TARGET_CohortsPreviewAPI
-from api_3.isb_cgc_api_TARGET.cohorts_create import TARGET_CohortsCreateAPI
-from api_3.isb_cgc_api_TARGET.patients_get import TARGET_CasesGetAPI
-from api_3.isb_cgc_api_TARGET.samples_get import TARGET_SamplesGetAPI
-from api_3.isb_cgc_api_TARGET.samples_cloudstoragefilepaths import TARGET_SamplesCloudStorageFilePathsAPI
-from api_3.isb_cgc_api_TARGET.users_get import TARGET_UserGetAPI
+from api_3.isb_cgc_api_TARGET.cohorts_preview import TARGETCohortsPreviewAPI
+from api_3.isb_cgc_api_TARGET.cohorts_create import TARGETCohortsCreateAPI
+from api_3.isb_cgc_api_TARGET.patients_get import TARGETCasesGetAPI
+from api_3.isb_cgc_api_TARGET.samples_get import TARGETSamplesGetAPI
+from api_3.isb_cgc_api_TARGET.samples_cloudstoragefilepaths import TARGETSamplesCloudStorageFilePathsAPI
+from api_3.isb_cgc_api_TARGET.users_get import TARGETUserGetAPI
  
-from api_3.isb_cgc_api_CCLE.cohorts_preview import CCLE_CohortsPreviewAPI
-from api_3.isb_cgc_api_CCLE.cohorts_create import CCLE_CohortsCreateAPI
-from api_3.isb_cgc_api_CCLE.patients_get import CCLE_CasesGetAPI
-from api_3.isb_cgc_api_CCLE.samples_get import CCLE_SamplesGetAPI
-from api_3.isb_cgc_api_CCLE.samples_cloudstoragefilepaths import CCLE_SamplesCloudStorageFilePathsAPI
+from api_3.isb_cgc_api_CCLE.cohorts_preview import CCLECohortsPreviewAPI
+from api_3.isb_cgc_api_CCLE.cohorts_create import CCLECohortsCreateAPI
+from api_3.isb_cgc_api_CCLE.patients_get import CCLECasesGetAPI
+from api_3.isb_cgc_api_CCLE.samples_get import CCLESamplesGetAPI
+from api_3.isb_cgc_api_CCLE.samples_cloudstoragefilepaths import CCLESamplesCloudStorageFilePathsAPI
  
 package = 'isb-cgc-api'
  
@@ -57,26 +57,26 @@ APPLICATION = endpoints.api_server([
     CohortFileManifestAPI,
     FilesGetPath,
  
-    TCGA_CohortsPreviewAPI,
-    TCGA_CohortsCreateAPI,
-    TCGA_CasesGetAPI,
-    TCGA_CasesAnnotationAPI,
-    TCGA_SamplesGetAPI,
-    TCGA_SamplesCloudStorageFilePathsAPI,
-    TCGA_SamplesAnnotationAPI,
-    TCGA_AliquotsAnnotationAPI,
-    TCGA_UserGetAPI,
+    TCGACohortsPreviewAPI,
+    TCGACohortsCreateAPI,
+    TCGACasesGetAPI,
+    TCGACasesAnnotationAPI,
+    TCGASamplesGetAPI,
+    TCGASamplesCloudStorageFilePathsAPI,
+    TCGASamplesAnnotationAPI,
+    TCGAAliquotsAnnotationAPI,
+    TCGAUserGetAPI,
          
-    TARGET_CohortsPreviewAPI,
-    TARGET_CohortsCreateAPI,
-    TARGET_CasesGetAPI,
-    TARGET_SamplesGetAPI,
-    TARGET_SamplesCloudStorageFilePathsAPI,
-    TARGET_UserGetAPI,
+    TARGETCohortsPreviewAPI,
+    TARGETCohortsCreateAPI,
+    TARGETCasesGetAPI,
+    TARGETSamplesGetAPI,
+    TARGETSamplesCloudStorageFilePathsAPI,
+    TARGETUserGetAPI,
          
-    CCLE_CohortsPreviewAPI,
-    CCLE_CohortsCreateAPI,
-    CCLE_CasesGetAPI,
-    CCLE_SamplesGetAPI,
-    CCLE_SamplesCloudStorageFilePathsAPI
+    CCLECohortsPreviewAPI,
+    CCLECohortsCreateAPI,
+    CCLECasesGetAPI,
+    CCLESamplesGetAPI,
+    CCLESamplesCloudStorageFilePathsAPI
 ])

--- a/cgc_api.py
+++ b/cgc_api.py
@@ -22,6 +22,7 @@ from api_3.isb_cgc_api.cohorts_get import CohortsGetAPI
 from api_3.isb_cgc_api.cohorts_list import CohortsListAPI
 from api_3.isb_cgc_api.cohorts_cloudstoragefilepaths import CohortsCloudStorageFilePathsAPI
 from api_3.isb_cgc_api.files_get_file_paths import FilesGetPath
+from api_3.isb_cgc_api.cohort_file_manifest import CohortFileManifestAPI
  
 from api_3.isb_cgc_api_TCGA.cohorts_preview import TCGA_CohortsPreviewAPI
 from api_3.isb_cgc_api_TCGA.cohorts_create import TCGA_CohortsCreateAPI
@@ -53,6 +54,7 @@ APPLICATION = endpoints.api_server([
     CohortsGetAPI,
     CohortsListAPI,
     CohortsCloudStorageFilePathsAPI,
+    CohortFileManifestAPI,
     FilesGetPath,
  
     TCGA_CohortsPreviewAPI,

--- a/settings.py
+++ b/settings.py
@@ -430,3 +430,19 @@ MANAGED_SERVICE_ACCOUNTS_PATH            = os.environ.get('MANAGED_SERVICE_ACCOU
 
 # Dataset configuration file path
 DATASET_CONFIGURATION_PATH               = os.environ.get('DATASET_CONFIGURATION_PATH', '')
+
+#################################
+#   For DCF login               #
+#################################
+
+DCF_AUTH_URL                             = os.environ.get('DCF_AUTH_URL', '')
+DCF_TOKEN_URL                            = os.environ.get('DCF_TOKEN_URL', '')
+DCF_USER_URL                             = os.environ.get('DCF_USER_URL', '')
+DCF_KEY_URL                              = os.environ.get('DCF_KEY_URL', '')
+DCF_GOOGLE_URL                           = os.environ.get('DCF_GOOGLE_URL', '')
+DCF_REVOKE_URL                           = os.environ.get('DCF_REVOKE_URL', '')
+DCF_LOGOUT_URL                           = os.environ.get('DCF_LOGOUT_URL', '')
+DCF_URL_URL                              = os.environ.get('DCF_URL_URL', '')
+DCF_CLIENT_SECRETS                       = os.environ.get('DCF_CLIENT_SECRETS', '')
+DCF_TOKEN_REFRESH_WINDOW_SECONDS         = int(os.environ.get('DCF_TOKEN_REFRESH_WINDOW_SECONDS', 86400))
+DCF_LOGIN_EXPIRATION_SECONDS             = int(os.environ.get('DCF_LOGIN_EXPIRATION_SECONDS', 86400))

--- a/settings.py
+++ b/settings.py
@@ -36,6 +36,13 @@ MANAGERS = ADMINS
 
 PROJECT_ID = os.environ.get('PROJECT_ID')
 BQ_PROJECT_ID = os.environ.get('BQ_PROJECT_ID')
+MAX_BQ_INSERT = int(os.environ.get('MAX_BQ_INSERT', '500'))
+BQ_MAX_ATTEMPTS = int(os.environ.get('MAX_BQ_ATTEMPTS', '10'))
+
+USER_DATA_ON = bool(os.environ.get('USER_DATA_ON', 'False') == 'True')
+
+MAX_FILE_LIST_REQUEST = int(os.environ.get('MAX_FILE_LIST_REQUEST', '50000'))
+MAX_FILES_IGV = int(os.environ.get('MAX_FILES_IGV', '5'))
 
 BASE_URL = os.environ.get('CLOUD_BASE_URL')
 BASE_API_URL = os.environ.get('CLOUD_API_URL')
@@ -360,17 +367,18 @@ INSTALLED_APP_CLIENT_ID         = os.environ.get('INSTALLED_APP_CLIENT_ID')
 #   For NIH/eRA Commons login   #
 #################################
 
-LOGIN_EXPIRATION_HOURS = 24
-OPEN_ACL_GOOGLE_GROUP               = os.environ.get('OPEN_ACL_GOOGLE_GROUP')
+LOGIN_EXPIRATION_MINUTES                = int(os.environ.get('LOGIN_EXPIRATION_MINUTES', 24*60))
+OPEN_ACL_GOOGLE_GROUP                   = os.environ.get('OPEN_ACL_GOOGLE_GROUP', '')
+GOOGLE_GROUP_ADMIN                      = os.environ.get('GOOGLE_GROUP_ADMIN', '')
+SUPERADMIN_FOR_REPORTS                  = os.environ.get('SUPERADMIN_FOR_REPORTS', '')
+ERA_LOGIN_URL                           = os.environ.get('ERA_LOGIN_URL', '')
+SAML_FOLDER                             = os.environ.get('SAML_FOLDER', '')
 
 ######################################
 #   For directory, reports services  #
 ######################################
 GOOGLE_GROUP_ADMIN           = os.environ.get('GOOGLE_GROUP_ADMIN', '')
 SUPERADMIN_FOR_REPORTS       = os.environ.get('SUPERADMIN_FOR_REPORTS', '')
-
-# Dataset configuration file path
-DATASET_CONFIGURATION_PATH   = os.environ.get('DATASET_CONFIGURATION_PATH', '')
 
 ##############################
 #   Start django-finalware   #
@@ -388,3 +396,37 @@ SITE_SUPERUSER_PASSWORD = os.environ.get('SU_PASS')
 ############################
 
 CONN_MAX_AGE = 0
+
+# Deployment module
+CRON_MODULE             = os.environ.get('CRON_MODULE')
+
+# TaskQueue used when users go through the ERA flow
+LOGOUT_WORKER_TASKQUEUE                  = os.environ.get('LOGOUT_WORKER_TASKQUEUE', '')
+CHECK_NIH_USER_LOGIN_TASK_URI            = os.environ.get('CHECK_NIH_USER_LOGIN_TASK_URI', '')
+
+# TaskQueue used by the sweep_nih_user_logins task
+LOGOUT_SWEEPER_FALLBACK_TASKQUEUE        = os.environ.get('LOGOUT_SWEEPER_FALLBACK_TASKQUEUE', '')
+
+# PubSub topic for ERA login notifications
+PUBSUB_TOPIC_ERA_LOGIN                   = os.environ.get('PUBSUB_TOPIC_ERA_LOGIN', '')
+
+# User project access key
+USER_GCP_ACCESS_CREDENTIALS              = os.environ.get('USER_GCP_ACCESS_CREDENTIALS', '')
+
+# Log name for ERA login views
+LOG_NAME_ERA_LOGIN_VIEW                  = os.environ.get('LOG_NAME_ERA_LOGIN_VIEW', '')
+
+# Log Names
+SERVICE_ACCOUNT_LOG_NAME = os.environ.get('SERVICE_ACCOUNT_LOG_NAME', 'local_dev_logging')
+
+# Service account blacklist file path
+SERVICE_ACCOUNT_BLACKLIST_PATH           = os.environ.get('SERVICE_ACCOUNT_BLACKLIST_PATH', '')
+
+# Google Org whitelist file path
+GOOGLE_ORG_WHITELIST_PATH                = os.environ.get('GOOGLE_ORG_WHITELIST_PATH', '')
+
+# Managed Service Account file path
+MANAGED_SERVICE_ACCOUNTS_PATH            = os.environ.get('MANAGED_SERVICE_ACCOUNTS_PATH', '')
+
+# Dataset configuration file path
+DATASET_CONFIGURATION_PATH               = os.environ.get('DATASET_CONFIGURATION_PATH', '')


### PR DESCRIPTION
-> Added ability to retrieve cohort file manifests, limit is 55k per request, supports limit and offset
-> Beginning work on cohort export
-> Refactor class names to remove underscores to support Google's Endpoints OpenAPI utility