### PR TITLE
Sprint 37

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
           command: |
             sudo -E /bin/bash ./shell/gcloud-pull-staging-files.sh
       - save_cache:
-          key: isb-cgc-api-{{ epoch }}
+          key: isb-cgc-api-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
           paths:
             - ./apiv4
             - ./shell
@@ -125,10 +125,6 @@ jobs:
             - ./txt
             - ./json
             - ./.env
-      - save_cache:
-          key: isb-cgc-api-{{ .Branch }}-{{ .Revision }}-
-          paths:
-            - ./.env
   deploy_job:
     environment:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
@@ -138,7 +134,7 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - isb-cgc-api-
+            - isb-cgc-api-{{ .Branch }}-{{ .Revision }}-
       - restore_cache:
           keys:
             - isb-cgc-api-google-deps-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,10 @@ jobs:
             - ./txt
             - ./json
             - ./.env
+      - save_cache:
+          key: isb-cgc-api-{{ .Branch }}-{{ .Revision }}-
+          paths:
+            - ./.env
   deploy_job:
     environment:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
@@ -135,9 +139,6 @@ jobs:
       - restore_cache:
           keys:
             - isb-cgc-api-
-      - restore_cache:
-          keys:
-            - isb-cgc-api-{{ .Branch }}-{{ .Revision }}-
       - restore_cache:
           keys:
             - isb-cgc-api-google-deps-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,10 +125,6 @@ jobs:
             - ./txt
             - ./json
             - ./.env
-      - save_cache:
-          key: isb-cgc-api-{{ .Environment.TIER }}-{{ epoch }}
-          paths:
-            - ./.end
   deploy_job:
     environment:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
@@ -141,7 +137,7 @@ jobs:
             - isb-cgc-api-
       - restore_cache:
           keys:
-            - isb-cgc-api-{{ .Environment.TIER }}-
+            - isb-cgc-api-{{ .Branch }}-{{ .Revision }}-
       - restore_cache:
           keys:
             - isb-cgc-api-google-deps-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,10 @@ jobs:
             - ./txt
             - ./json
             - ./.env
-
+      - save_cache:
+          key: isb-cgc-api-{{ .Environment.TIER }}-{{ epoch }}
+          paths:
+            - ./.end
   deploy_job:
     environment:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
@@ -136,6 +139,9 @@ jobs:
       - restore_cache:
           keys:
             - isb-cgc-api-
+      - restore_cache:
+          keys:
+            - isb-cgc-api-{{ .Environment.TIER }}-
       - restore_cache:
           keys:
             - isb-cgc-api-google-deps-


### PR DESCRIPTION
- Use Branch and Revision in cache to prevent cache collisions at deployment time